### PR TITLE
Add CI matrix for Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests (Unix)
+        if: runner.os != 'Windows'
+        run: ./gradlew --no-daemon test
+
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        run: .\\gradlew.bat --no-daemon test

--- a/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
+++ b/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -36,8 +37,8 @@ public class KuromojiCliTest {
 
     @BeforeEach
     public void setUpStreams() {
-        System.setOut(new PrintStream(outContent));
-        System.setErr(new PrintStream(errContent));
+        System.setOut(new PrintStream(outContent, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(errContent, true, StandardCharsets.UTF_8));
     }
     String getDefaultString() {
         return "早稲田大学";
@@ -51,6 +52,6 @@ public class KuromojiCliTest {
     public void tokenize() {
         KuromojiCli target = new KuromojiCli();
         target.tokenize(getDefaultString(), Output.wakati, DictionaryType.ipadic, TokenizerBase.Mode.EXTENDED);
-        assertEquals(getExpectedTokens(), outContent.toString());
+        assertEquals(getExpectedTokens(), outContent.toString(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for tests
- run on ubuntu-latest and windows-latest
- execute Gradle tests on push/PR/manual dispatch

## Why
- prevent OS-dependent regressions in test expectations (e.g. line separators)
- continuously verify cross-platform behavior

Refs #8