### PR TITLE
Fix stdin handling when input file is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Also the file can be specified as a parameter.
 関西 関西国際空港 国際 空港 限定 トートバッグ
 ```
 
+If `<filename>` is specified, `kuromoji` reads only the file and does not read from standard input.
+
 ### Dictionary Type
 
 `ipadic`, `unidic`, `naist_jdic`, `jumandic`, and `unidic_kanaaccent` can be specified. Default is `ipadic`.

--- a/src/main/java/info/johtani/misc/cli/kuromoji/KuromojiCli.java
+++ b/src/main/java/info/johtani/misc/cli/kuromoji/KuromojiCli.java
@@ -79,6 +79,7 @@ public class KuromojiCli implements Callable<Integer> {
                         tokenize(line, output, dictType, mode);
                     }
                 }
+                return exitCode;
             }
 
             try (Scanner stdin = new Scanner(System.in)) {

--- a/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
+++ b/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
@@ -84,8 +84,8 @@ public class KuromojiCliTest {
     public void callWithInputFileShouldIgnoreStdin() throws IOException {
         Path inputPath = Files.createTempFile("kuromoji-cli-", ".txt");
         try {
-            Files.writeString(inputPath, "東京都", StandardCharsets.UTF_8);
-            System.setIn(new ByteArrayInputStream("京都府\n".getBytes(StandardCharsets.UTF_8)));
+            Files.writeString(inputPath, "FILEMARKER\n", StandardCharsets.UTF_8);
+            System.setIn(new ByteArrayInputStream("STDINMARKER\n".getBytes(StandardCharsets.UTF_8)));
 
             KuromojiCli target = new KuromojiCli();
             target.inputFile = inputPath.toString();
@@ -95,13 +95,10 @@ public class KuromojiCliTest {
 
             int exitCode = target.call();
             String output = outContent.toString(StandardCharsets.UTF_8).trim();
-            Set<String> tokens = Stream.of(output.split("\\s+"))
-                    .filter(token -> token.isEmpty() == false)
-                    .collect(Collectors.toSet());
 
             assertEquals(0, exitCode);
-            assertTrue(tokens.contains("東京") || tokens.contains("東京都"));
-            assertFalse(tokens.contains("京都") || tokens.contains("京都府"));
+            assertFalse(output.isEmpty());
+            assertFalse(output.contains("STDINMARKER"));
         } finally {
             Files.deleteIfExists(inputPath);
         }

--- a/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
+++ b/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
@@ -23,13 +23,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -39,6 +44,7 @@ public class KuromojiCliTest {
     final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
     final PrintStream originalOut = System.out;
     final PrintStream originalErr = System.err;
+    final java.io.InputStream originalIn = System.in;
 
     @BeforeEach
     public void setUpStreams() {
@@ -50,6 +56,7 @@ public class KuromojiCliTest {
     public void restoreStreams() {
         System.setOut(originalOut);
         System.setErr(originalErr);
+        System.setIn(originalIn);
     }
 
     String getDefaultString() {
@@ -71,5 +78,26 @@ public class KuromojiCliTest {
         boolean containsCompound = tokens.contains("早稲田大学");
         boolean containsSplit = tokens.contains("早稲田") && tokens.contains("大学");
         assertTrue(containsCompound || containsSplit);
+    }
+
+    @Test
+    public void callWithInputFileShouldIgnoreStdin() throws IOException {
+        Path inputPath = Files.createTempFile("kuromoji-cli-", ".txt");
+        Files.writeString(inputPath, "東京都", StandardCharsets.UTF_8);
+        System.setIn(new ByteArrayInputStream("京都府\n".getBytes(StandardCharsets.UTF_8)));
+
+        KuromojiCli target = new KuromojiCli();
+        target.inputFile = inputPath.toString();
+        target.output = Output.wakati;
+        target.dictType = DictionaryType.ipadic;
+        target.mode = TokenizerBase.Mode.EXTENDED;
+
+        int exitCode = target.call();
+        String output = outContent.toString(StandardCharsets.UTF_8);
+        Files.deleteIfExists(inputPath);
+
+        assertEquals(0, exitCode);
+        assertTrue(output.contains("東京"));
+        assertFalse(output.contains("京都"));
     }
 }

--- a/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
+++ b/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
@@ -83,21 +83,27 @@ public class KuromojiCliTest {
     @Test
     public void callWithInputFileShouldIgnoreStdin() throws IOException {
         Path inputPath = Files.createTempFile("kuromoji-cli-", ".txt");
-        Files.writeString(inputPath, "東京都", StandardCharsets.UTF_8);
-        System.setIn(new ByteArrayInputStream("京都府\n".getBytes(StandardCharsets.UTF_8)));
+        try {
+            Files.writeString(inputPath, "東京都", StandardCharsets.UTF_8);
+            System.setIn(new ByteArrayInputStream("京都府\n".getBytes(StandardCharsets.UTF_8)));
 
-        KuromojiCli target = new KuromojiCli();
-        target.inputFile = inputPath.toString();
-        target.output = Output.wakati;
-        target.dictType = DictionaryType.ipadic;
-        target.mode = TokenizerBase.Mode.EXTENDED;
+            KuromojiCli target = new KuromojiCli();
+            target.inputFile = inputPath.toString();
+            target.output = Output.wakati;
+            target.dictType = DictionaryType.ipadic;
+            target.mode = TokenizerBase.Mode.EXTENDED;
 
-        int exitCode = target.call();
-        String output = outContent.toString(StandardCharsets.UTF_8);
-        Files.deleteIfExists(inputPath);
+            int exitCode = target.call();
+            String output = outContent.toString(StandardCharsets.UTF_8).trim();
+            Set<String> tokens = Stream.of(output.split("\\s+"))
+                    .filter(token -> token.isEmpty() == false)
+                    .collect(Collectors.toSet());
 
-        assertEquals(0, exitCode);
-        assertTrue(output.contains("東京"));
-        assertFalse(output.contains("京都"));
+            assertEquals(0, exitCode);
+            assertTrue(tokens.contains("東京") || tokens.contains("東京都"));
+            assertFalse(tokens.contains("京都") || tokens.contains("京都府"));
+        } finally {
+            Files.deleteIfExists(inputPath);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- stop reading `stdin` when `inputFile` is specified
- add a regression test for `inputFile` precedence over `stdin`
- document the behavior in README

## Testing
- `./gradlew.bat test --tests info.johtani.misc.cli.kuromoji.KuromojiCliTest`

Closes #10
