### PR TITLE
feat: support selectable tokenizer engine (Atilika/Lucene)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Command Line Interface for Atilika Kuromoji
+# Command Line Interface for Kuromoji (Atilika/Lucene)
 
-This plugin provide Command Line Interface for Atilika Kuromoji.
+This plugin provide Command Line Interface for Atilika Kuromoji and Lucene Kuromoji.
 
 
 ## Build
 
 ### Requirements
 
-* JDK >= 17
+* JDK >= 21
 * Gradle Wrapper (`./gradlew`) を利用
 
 ### Build Native Image using JDK
@@ -42,10 +42,19 @@ If `<filename>` is specified, `kuromoji` reads only the file and does not read f
 
 `ipadic`, `unidic`, `naist_jdic`, `jumandic`, and `unidic_kanaaccent` can be specified. Default is `ipadic`.
 
+### Engine
+
+`atilika` and `lucene` can be specified by `-e` / `--engine`. Default is `atilika`.
+
+If `lucene` is selected:
+
+* `-d` / `--dictionary` is ignored with warning, and tokenization runs as ipadic-equivalent behavior.
+* `-v` / `--viterbi` is not supported and emits warning.
+
 ### Tokenize mode
 
 `NORMAL`, `SEARCH`, `EXTENDED` can be specified. Default is `SEARCH`.
-*NOTE: This option can only use with `-d=ipadic`.*
+*NOTE: With Atilika engine, `-m` is effective for `-d=ipadic`.*
 
 ```
 % echo "関西国際空港限定トートバッグ" | kuromoji -m=NORMAL
@@ -76,7 +85,8 @@ EOS
 
 Kuromoji allow to output Viterbi lattice and path as [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) format.
 This is debug purpose, but it is helpful to understand token outputs.
-If `-v` or `--viterbi` option is specified, **the command outputs DOT file to stdout and outputs tokens to stderr.** 
+If `-v` or `--viterbi` option is specified with `--engine=atilika`, **the command outputs DOT file to stdout and outputs tokens to stderr.**
+With `--engine=lucene`, this option is not supported and emits warning.
 
 ```sh
 % echo "関西国際空港限定トートバッグ" | build/graal/kuromoji -v > viterbi.dot

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ description "Kuromoji CLI"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 
@@ -28,6 +28,9 @@ dependencies {
     implementation "com.atilika.kuromoji:kuromoji-unidic-kanaaccent:${kuromojiVersion}"
     implementation "com.atilika.kuromoji:kuromoji-jumandic:${kuromojiVersion}"
     implementation "com.atilika.kuromoji:kuromoji-naist-jdic:${kuromojiVersion}"
+    implementation "org.apache.lucene:lucene-core:${luceneVersion}"
+    implementation "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
+    implementation "org.apache.lucene:lucene-analysis-kuromoji:${luceneVersion}"
     implementation 'info.picocli:picocli:4.7.7'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.1'
     annotationProcessor 'info.picocli:picocli-codegen:4.7.7'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 kuromojiVersion = 0.9.0
+luceneVersion = 10.4.0

--- a/src/main/java/info/johtani/misc/cli/kuromoji/KuromojiCli.java
+++ b/src/main/java/info/johtani/misc/cli/kuromoji/KuromojiCli.java
@@ -19,10 +19,20 @@ package info.johtani.misc.cli.kuromoji;
 import com.atilika.kuromoji.TokenBase;
 import com.atilika.kuromoji.TokenizerBase;
 import info.johtani.misc.cli.kuromoji.output.AtilikaTokenInfo;
+import info.johtani.misc.cli.kuromoji.output.LuceneTokenInfo;
 import info.johtani.misc.cli.kuromoji.output.Output;
 import info.johtani.misc.cli.kuromoji.output.OutputBuilder;
 import info.johtani.misc.cli.kuromoji.tokenizer.DictionaryType;
+import info.johtani.misc.cli.kuromoji.tokenizer.EngineType;
 import info.johtani.misc.cli.kuromoji.tokenizer.TokenizerFactory;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.ja.JapaneseTokenizer;
+import org.apache.lucene.analysis.ja.tokenattributes.BaseFormAttribute;
+import org.apache.lucene.analysis.ja.tokenattributes.InflectionAttribute;
+import org.apache.lucene.analysis.ja.tokenattributes.PartOfSpeechAttribute;
+import org.apache.lucene.analysis.ja.tokenattributes.ReadingAttribute;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
@@ -30,6 +40,7 @@ import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.io.StringReader;
 import java.util.List;
 import java.util.Scanner;
 import java.util.concurrent.Callable;
@@ -62,6 +73,11 @@ public class KuromojiCli implements Callable<Integer> {
     )
     DictionaryType dictType = DictionaryType.ipadic;
 
+    @Option(names = {"-e", "--engine"},
+            description = "The tokenizer engine. ${COMPLETION-CANDIDATES} can be specified. Default is ${DEFAULT-VALUE}"
+    )
+    EngineType engine = EngineType.atilika;
+
     @Option(names = {"-v", "--viterbi"},
             defaultValue = "false",
             description = "The output viterbi lattice as DOT format to stdout. And token list is output as stderr"
@@ -72,6 +88,7 @@ public class KuromojiCli implements Callable<Integer> {
     public Integer call() {
         int exitCode = 0;
         try {
+            warnUnsupportedOptionsForLucene();
             if (inputFile != null && inputFile.isEmpty() == false) {
                 try (BufferedReader bufferedReader = new BufferedReader(new FileReader(inputFile))) {
                     String line;
@@ -96,7 +113,16 @@ public class KuromojiCli implements Callable<Integer> {
         return exitCode;
     }
 
-    void tokenize(String input, Output output, DictionaryType dictType, Mode mode){
+    void tokenize(String input, Output output, DictionaryType dictType, Mode mode) {
+        if (engine == EngineType.lucene) {
+            tokenizeWithLucene(input, output, mode);
+            return;
+        }
+
+        tokenizeWithAtilika(input, output, dictType, mode);
+    }
+
+    private void tokenizeWithAtilika(String input, Output output, DictionaryType dictType, Mode mode) {
         PrintStream outputStream = System.out;
         if (outputViterbi) {
             outputStream = System.err;
@@ -119,6 +145,56 @@ public class KuromojiCli implements Callable<Integer> {
                 System.err.println(e.getMessage());
                 e.printStackTrace();
             }
+        }
+    }
+
+    private void tokenizeWithLucene(String input, Output output, Mode mode) {
+        OutputBuilder outputBuilder = OutputBuilder.Factory.create(output, System.out);
+        JapaneseTokenizer.Mode luceneMode = JapaneseTokenizer.Mode.valueOf(mode.name());
+
+        try (Analyzer analyzer = new Analyzer() {
+            @Override
+            protected TokenStreamComponents createComponents(String fieldName) {
+                JapaneseTokenizer tokenizer = new JapaneseTokenizer(null, false, luceneMode);
+                return new TokenStreamComponents(tokenizer);
+            }
+        };
+             TokenStream tokenStream = analyzer.tokenStream("ignored", new StringReader(input))) {
+            CharTermAttribute charTerm = tokenStream.getAttribute(CharTermAttribute.class);
+            PartOfSpeechAttribute pos = tokenStream.getAttribute(PartOfSpeechAttribute.class);
+            ReadingAttribute reading = tokenStream.getAttribute(ReadingAttribute.class);
+            InflectionAttribute inflection = tokenStream.getAttribute(InflectionAttribute.class);
+            BaseFormAttribute baseForm = tokenStream.getAttribute(BaseFormAttribute.class);
+
+            tokenStream.reset();
+            while (tokenStream.incrementToken()) {
+                outputBuilder.addTerm(new LuceneTokenInfo(
+                        charTerm.toString(),
+                        pos.getPartOfSpeech(),
+                        inflection.getInflectionType(),
+                        inflection.getInflectionForm(),
+                        baseForm.getBaseForm(),
+                        reading.getReading(),
+                        reading.getPronunciation()
+                ));
+            }
+            tokenStream.end();
+            outputBuilder.output();
+        } catch (IOException ioe) {
+            throw new IllegalStateException("Failed to tokenize with Lucene Kuromoji.", ioe);
+        }
+    }
+
+    private void warnUnsupportedOptionsForLucene() {
+        if (engine != EngineType.lucene) {
+            return;
+        }
+
+        if (dictType != DictionaryType.ipadic) {
+            System.err.println("WARNING: --dictionary is ignored when --engine=lucene. Running with ipadic-equivalent behavior.");
+        }
+        if (outputViterbi) {
+            System.err.println("WARNING: --viterbi is not supported when --engine=lucene. Continuing without DOT output.");
         }
     }
 

--- a/src/main/java/info/johtani/misc/cli/kuromoji/output/LuceneTokenInfo.java
+++ b/src/main/java/info/johtani/misc/cli/kuromoji/output/LuceneTokenInfo.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020 johtani
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.johtani.misc.cli.kuromoji.output;
+
+public class LuceneTokenInfo extends TokenInfo {
+    private final String allFeatures;
+
+    public LuceneTokenInfo(String token,
+                           String partOfSpeech,
+                           String inflectionType,
+                           String inflectionForm,
+                           String baseForm,
+                           String reading,
+                           String pronunciation) {
+        super(token);
+        String[] pos = toPosFields(partOfSpeech);
+        this.allFeatures = String.join(",",
+                pos[0],
+                pos[1],
+                pos[2],
+                pos[3],
+                normalize(inflectionType),
+                normalize(inflectionForm),
+                normalize(baseForm),
+                normalize(reading),
+                normalize(pronunciation)
+        );
+    }
+
+    @Override
+    public String getAllFeatures() {
+        return allFeatures;
+    }
+
+    private static String[] toPosFields(String partOfSpeech) {
+        String[] pos = {"*", "*", "*", "*"};
+        if (partOfSpeech == null || partOfSpeech.isEmpty()) {
+            return pos;
+        }
+
+        String[] raw = partOfSpeech.split(",");
+        for (int i = 0; i < pos.length && i < raw.length; i++) {
+            pos[i] = normalize(raw[i]);
+        }
+        return pos;
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isEmpty()) {
+            return "*";
+        }
+        // Lucene sometimes returns whitespace-only features.
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? "*" : trimmed;
+    }
+}

--- a/src/main/java/info/johtani/misc/cli/kuromoji/tokenizer/EngineType.java
+++ b/src/main/java/info/johtani/misc/cli/kuromoji/tokenizer/EngineType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020 johtani
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.johtani.misc.cli.kuromoji.tokenizer;
+
+public enum EngineType {
+    atilika,
+    lucene
+}

--- a/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
+++ b/src/test/java/info/johtani/misc/cli/kuromoji/KuromojiCliTest.java
@@ -19,9 +19,11 @@ package info.johtani.misc.cli.kuromoji;
 import com.atilika.kuromoji.TokenizerBase;
 import info.johtani.misc.cli.kuromoji.output.Output;
 import info.johtani.misc.cli.kuromoji.tokenizer.DictionaryType;
+import info.johtani.misc.cli.kuromoji.tokenizer.EngineType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -102,5 +104,31 @@ public class KuromojiCliTest {
         } finally {
             Files.deleteIfExists(inputPath);
         }
+    }
+
+    @Test
+    public void defaultEngineShouldBeAtilika() {
+        KuromojiCli target = new KuromojiCli();
+        new CommandLine(target).parseArgs();
+        assertEquals(EngineType.atilika, target.engine);
+    }
+
+    @Test
+    public void luceneEngineShouldWarnForUnsupportedOptions() {
+        System.setIn(new ByteArrayInputStream((getDefaultString() + "\n").getBytes(StandardCharsets.UTF_8)));
+
+        KuromojiCli target = new KuromojiCli();
+        target.engine = EngineType.lucene;
+        target.dictType = DictionaryType.unidic;
+        target.outputViterbi = true;
+
+        int exitCode = target.call();
+        String errOutput = errContent.toString(StandardCharsets.UTF_8);
+        String output = outContent.toString(StandardCharsets.UTF_8).trim();
+
+        assertEquals(0, exitCode);
+        assertTrue(errOutput.contains("--dictionary is ignored"));
+        assertTrue(errOutput.contains("--viterbi is not supported"));
+        assertFalse(output.isEmpty());
     }
 }


### PR DESCRIPTION
## Summary
- add `--engine` (`atilika`/`lucene`) and keep default as `atilika` for backward compatibility
- implement Lucene tokenization path and map Lucene attributes into existing output formats
- add warnings when unsupported options are used with Lucene:
  - ignore `--dictionary` and run in ipadic-equivalent behavior
  - ignore `--viterbi` DOT output
- upgrade Lucene to `10.4.0` and align artifacts with `lucene-analysis-*`
- raise Java toolchain to 21 (required by Lucene 10.x)
- update README and add CLI tests for engine default and warning behavior

## Testing
- `./gradlew.bat test`

Closes #23
